### PR TITLE
fix: Keep MQTT worker alive when sensor data is unavailable

### DIFF
--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -58,13 +58,14 @@ void mqttWorker(void *params)
         if (WiFi.status() != WL_CONNECTED)
         {
             Serial.println("Error in WiFi connection");
-            return;
+            continue;
         }
 
         JsonDocument doc;
         if (!getMinimalSensorData(doc))
         {
-            return;
+            Serial.println("MQTT: no sensor data available yet");
+            continue;
         }
         size_t json_len = measureJson(doc);
         static unsigned char json_body[256]; // expected json len is 225 bytes


### PR DESCRIPTION
This PR adresses a crash when data was not yet available, instead of breaking out of the loop we continue